### PR TITLE
duration millis used to wait is not initialized in WebSocket::checkCo…

### DIFF
--- a/third_party/IXWebSocket/ixwebsocket/IXWebSocket.cpp
+++ b/third_party/IXWebSocket/ixwebsocket/IXWebSocket.cpp
@@ -222,7 +222,7 @@ namespace ix
         using millis = std::chrono::duration<double, std::milli>;
 
         uint32_t retries = 0;
-        millis duration;
+        millis duration(0);
 
         // Try to connect perpertually
         while (true)


### PR DESCRIPTION
…nnection

This caused infinite wait and hangs on devices such as the Amazon Kindle or other Android devices.

https://stackoverflow.com/questions/46402944/how-does-stdchronoduration-default-constructed